### PR TITLE
Fix data-consistency module

### DIFF
--- a/data/transforms.py
+++ b/data/transforms.py
@@ -70,6 +70,42 @@ def apply_mask(data, mask_func, seed=None):
     return data * mask, mask
 
 
+def ifft2c(x, dim=(-2, -1)):
+    """ Centered 2D Inverse Fast Fourier Transform
+
+    Args:
+        x (torch.Tensor): Complex valued input data containing at least 3
+            dimensions: dimensions -2 & -1 are spatial dimensions. All other 
+            dimensions are assumed to be batch dimensions.
+        dim (tuple): Dimensions to apply the IFFT along. Default is (-2, -1)
+
+    Returns:
+        torch.Tensor: The IFFT of the input.
+    """
+    x = torch.fft.ifftshift(x, dim=dim)
+    x = torch.fft.ifft2(x, dim=dim)
+    return torch.fft.fftshift(x, dim=dim)
+
+
+def fft2(data, normalized=True):
+    """
+    Apply centered 2 dimensional Fast Fourier Transform.
+
+    Args:
+        data (torch.Tensor): Complex valued input data containing at least 3 dimensions: dimensions
+            -3 & -2 are spatial dimensions and dimension -1 has size 2. All other dimensions are
+            assumed to be batch dimensions.
+
+    Returns:
+        torch.Tensor: The FFT of the input.
+    """
+    assert data.size(-1) == 2
+    data = ifftshift(data, dim=(-3, -2))
+    data = torch.fft.fft(data, 2, normalized=normalized)
+    data = fftshift(data, dim=(-3, -2))
+    return data
+
+
 def fft2(data, normalized=True):
     """
     Apply centered 2 dimensional Fast Fourier Transform.

--- a/data/transforms.py
+++ b/data/transforms.py
@@ -70,6 +70,24 @@ def apply_mask(data, mask_func, seed=None):
     return data * mask, mask
 
 
+def fft2c(x, dim=(-2, -1)):
+    """ Centered 2D Fast Fourier Transform 
+    
+    Args:
+        x (torch.Tensor): Complex valued input data containing at least 3
+            dimensions: dimensions -2 & -1 are spatial dimensions. All other 
+            dimensions are assumed to be batch dimensions.
+
+        dim (tuple): Dimensions to apply the FFT along. Default is (-2, -1)
+
+    Returns:
+        torch.Tensor: The FFT of the input.
+    """
+    x = torch.fft.ifftshift(x, dim=dim)
+    x = torch.fft.fft2(x, dim=dim)
+    return torch.fft.fftshift(x, dim=dim)
+
+
 def ifft2c(x, dim=(-2, -1)):
     """ Centered 2D Inverse Fast Fourier Transform
 
@@ -85,25 +103,6 @@ def ifft2c(x, dim=(-2, -1)):
     x = torch.fft.ifftshift(x, dim=dim)
     x = torch.fft.ifft2(x, dim=dim)
     return torch.fft.fftshift(x, dim=dim)
-
-
-def fft2(data, normalized=True):
-    """
-    Apply centered 2 dimensional Fast Fourier Transform.
-
-    Args:
-        data (torch.Tensor): Complex valued input data containing at least 3 dimensions: dimensions
-            -3 & -2 are spatial dimensions and dimension -1 has size 2. All other dimensions are
-            assumed to be batch dimensions.
-
-    Returns:
-        torch.Tensor: The FFT of the input.
-    """
-    assert data.size(-1) == 2
-    data = ifftshift(data, dim=(-3, -2))
-    data = torch.fft.fft(data, 2, normalized=normalized)
-    data = fftshift(data, dim=(-3, -2))
-    return data
 
 
 def fft2(data, normalized=True):


### PR DESCRIPTION
### Summary

Fixes #10

This PR addresses the problem with data-consistency module and 2D Fourier transform functions `fft2`, and `ifft2`. The data-consistency module has been updated, `fft2c` and `ifft2c` functions are added to `transforms.py`.

### Problem definition

The below data-consistency module does not work:

https://github.com/guopengf/ReconFormer/blob/e2e0d5e6e58e04ad1c77a1151e63cf56bec21fb1/models/Recurrent_Transformer.py#L13-L55

This is due to some errors in `fft2` and `ifft2` functions in `transforms.py`:

https://github.com/guopengf/ReconFormer/blob/e2e0d5e6e58e04ad1c77a1151e63cf56bec21fb1/data/transforms.py#L73-L107

### To Reproduce

```python

import torch
from backbones.reconformer.reconformer import DataConsistencyInKspace

resolution = 320
device = 'cuda:0'

x = torch.randn((1, 2, resolution, resolution)).to(device)
k0 = torch.randn((1, 2, resolution, resolution)).to(device)
mask = torch.randn((1, 1, resolution, resolution)).to(device)

dc = DataConsistencyInKspace()
out = dc(x, k0, mask)

print(f"Input shape: {x.shape}")
print(f"Output shape: {out.shape}")
```

```
     46 k0 = k0.permute(0, 2, 3, 1)
     47 mask = mask.permute(0, 2, 3, 1)
...
--> 122 data = torch.fft.fft(data, 2, normalized=normalized)
    123 data = fftshift(data, dim=(-3, -2))
    124 return data

TypeError: fft_fft() got an unexpected keyword argument 'normalized'
```


